### PR TITLE
Fix logic checking the ignore_lostfound argument.

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -91,8 +91,8 @@ function isDirectoryEmpty
 	shopt -s nullglob || *
 
 	ignore_lostfound=1
-	test -n "$2" -a "$2" != 0 || ignore_lostfound=
-	
+	test -n "$2" -a "$2" != 0 && ignore_lostfound=
+
 	for i in "$1"/*; do
 	    case "$i" in
 		($1/lost+found)


### PR DESCRIPTION
- Check with:
  
  $ unset ilost;    test -n "$ilost" -a "$ilost" != 0 && echo "setting ignore_lostfound="
  
  $ ilost=0;        test -n "$ilost" -a "$ilost" != 0 && echo "setting ignore_lostfound="
  
  $ ilost=1;        test -n "$ilost" -a "$ilost" != 0 && echo "setting ignore_lostfound="
    setting ignore_lostfound=
