### PR TITLE
Fix ignore_lostfound logic:

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -91,8 +91,8 @@ function isDirectoryEmpty
 	shopt -s nullglob || *
 
 	ignore_lostfound=1
-	test -n "$2" -a "$2" != 0 || ignore_lostfound=
-	
+	test -n "$2" -a "$2" = 0 && ignore_lostfound=
+
 	for i in "$1"/*; do
 	    case "$i" in
 		($1/lost+found)


### PR DESCRIPTION
- The previous test was disabling ignore_lostfound always that
  $2 was not set because 'test -n "$2" -a ...' will fail every
  time that $2 is not set.
- Fix logic so it only disables ignore_lostfound when $2 is set
  and it has a value of 0.
