### PR TITLE
Don't overwrite util-vserver-vars if libexec and lib are the same.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,8 +220,10 @@ _install-vserverdir:
 			$(mkinstalldirs) $(DESTDIR)$(vserverdir) $(DESTDIR)$(vserverpkgdir)
 
 _install-varlink:
+ifneq ($(pkglibexecdir),$(pkglibdir))
 			$(mkinstalldirs) $(DESTDIR)/${pkglibdir}
 			ln -s ${pkglibexecdir}/util-vserver-vars $(DESTDIR)/${pkglibdir}/util-vserver-vars
+endif
 			ln -s ${pkglibexecdir}/util-vserver-vars $(DESTDIR)/${pkgdatadir}/util-vserver-vars
 
 .fixups:		config.status util-vserver.spec


### PR DESCRIPTION
Make util-vserver-vars link creation conditional upon libexec and lib
being different directories.

If libexec and lib are the same, as when building a Debian package
with the provided debian/rules, then `make install-distribution` fails
with:

    ln: failed to create symbolic link
    `debian/tmp//usr/lib/x86_64-linux-gnu/util-vserver/util-vserver-vars':
    File exists