### PR TITLE
Source util-vserver vars in gentoo initscript

### DIFF
--- a/gentoo/vservers.default
+++ b/gentoo/vservers.default
@@ -13,6 +13,7 @@ start() {
 		eerror "(the file '$UTIL_VSERVER_VARS' would be expected)"
 		return 1
 	fi
+	. ${UTIL_VSERVER_VARS}
 	MARK=${SVCNAME#vservers.} $_VSERVER_WRAPPER start
 }
 
@@ -23,6 +24,7 @@ stop() {
 		eerror "(the file '$UTIL_VSERVER_VARS' would be expected)"
 		return 1
 	fi
+	. ${UTIL_VSERVER_VARS}
 	MARK=${SVCNAME#vservers.} $_VSERVER_WRAPPER stop
 }
 


### PR DESCRIPTION
As explained on the mailing list, the gentoo vservers.default script is broken as it does not source for the util-vserver vars. This simple patch fixes the problem.