### PR TITLE
add .xz support for h2ext to be able to build from tar.xz templates

### DIFF
--- a/distrib/misc/h2ext.desc
+++ b/distrib/misc/h2ext.desc
@@ -17,3 +17,5 @@
 # dump/restore old-fs big and little endian
 24	belong		60011			restore -rf -			0
 24	lelong		60011			restore -rf -			0
+# xz
+0	string		\375\67zXZ\0		xz -d -c			1


### PR DESCRIPTION
magic taken from
https://github.com/file/file/blob/FILE5_24/magic/Magdir/compress#L202-L205

however due limited support of magic format in util-vserver had to hack
some things:

- does not support 'ustring', used 'string'
- does not support \xXX hex escape, used octal
- unable parse octal properly \375 + 7 would be parsed as \3757, so encoded '7' as \67

$ head -c6 < pld32.tar.xz|od -cx
0000000 375   7   z   X   Z  \0
           37fd    587a    005a