### PR TITLE
systemd: Fix shared mounts (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 *.a
+*.o
 .*.stamp
 .X_*etc-up-to-date
 .deps
 .fixups
+.systemd/
 ChangeLog
 FEATURES.txt
 INSTALL
@@ -11,6 +13,7 @@ Makefile.in
 aclocal.m4
 autom4te.cache
 compile
+config.cache
 config.guess
 config.h
 config.h.in
@@ -34,9 +37,13 @@ python/.dirstamp
 python/.libs/
 python/_libvserver-constants.c
 python/python__libvserver_la-_libvserver.lo
+scripts/vshelper
 src/exec-remount
 src/tunctl
 stamp-h1
+systemd/*.service
+systemd/.dirstamp
+test-driver
 util-vserver-*.tar.*
 util-vserver.spec
 *.orig

--- a/lib_internal/util-cleanupmount.c
+++ b/lib_internal/util-cleanupmount.c
@@ -27,8 +27,8 @@
 #ifndef MS_REC
 #define MS_REC		0x4000
 #endif
-#ifndef MS_PRIVATE
-#define MS_PRIVATE	(1<<18)
+#ifndef MS_SLAVE
+#define MS_SLAVE	(1<<19)
 #endif
 
 bool cleanupMount(void)
@@ -37,9 +37,9 @@ bool cleanupMount(void)
 
   /* systemd mounts everything with MS_SHARED which breaks our
    * filesystem mounting.  Revert mount status back to pre-systemd */
-  rc = mount(NULL, "/", NULL, MS_REC|MS_PRIVATE, NULL) >= 0;
+  rc = mount(NULL, "/", NULL, MS_REC|MS_SLAVE, NULL) >= 0;
   if (!rc)
-    perror("mount(\"/\", MS_REC|MS_PRIVATE)");
+    perror("mount(\"/\", MS_REC|MS_SLAVE)");
 
   return rc;
 }

--- a/src/vcontext.c
+++ b/src/vcontext.c
@@ -313,6 +313,8 @@ doit(struct Arguments const *args, int argc, char *argv[])
 	  perror(ENSC_WRAPPERS_PREFIX "unshare(NEWNS)");
 	  return wrapper_exit_code;
 	}
+	if (!cleanupMount())
+	  return wrapper_exit_code;
 	if (mkdir("./.oldroot", 0700) == -1) {
 	  if (errno == EEXIST)
 	    existed = true;

--- a/src/vspace.c
+++ b/src/vspace.c
@@ -137,6 +137,8 @@ newSpaces(uint_least64_t mask)
       perror(ENSC_WRAPPERS_PREFIX "clone()");
       exit(wrapper_exit_code);
     case 0	:
+      if (mask & CLONE_NEWNS)
+	cleanupMount();
       break;
     default	:
       vc_exitLikeProcess(pid, wrapper_exit_code);


### PR DESCRIPTION
We tried to fix the systemd stuff with the shared mounts in 2698c20ae42860b10b21174a2c67db2e1d0ecc29 and 7c2397d7c11185680b167fbb0e8bbfb62cb338ca, broke vmount (mount from the admin namespace), reverted the commit in 56d2df4f2a4d47471bda42c42d11ce4564937d69 and broke support with systemd on the host.

After reading the documentation about [shared subtrees](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) I am pretty sure, that we do not want to have private mounts but slave mounts. That way the mounts from parent namespaces could propagate into the vserver, but the changes made while starting the container does not propagate up to the host.
